### PR TITLE
Use HTTPS for documentation site

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -1,4 +1,4 @@
-baseUrl: http://phpactor.github.io/phpactor
+baseUrl: https://phpactor.github.io/phpactor
 
 include:
     - doc


### PR DESCRIPTION
Changing the baseUrl to `https` allows access to the doc site using an authenticated connection.

Before this change, the docs site will throw mixed content errors and not render properly.